### PR TITLE
Update lg.py

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -221,7 +221,7 @@ def whois():
 
 
 SUMMARY_UNWANTED_PROTOS = ["Kernel", "Static", "Device"]
-SUMMARY_RE_MATCH = r"(?P<name>[\w_]+)\s+(?P<proto>\w+)\s+(?P<table>\w+)\s+(?P<state>\w+)\s+(?P<since>((|\d\d\d\d-\d\d-\d\d\s)(|\d\d:)\d\d:\d\d|\w\w\w\d\d))($|\s+(?P<info>.*))"
+SUMMARY_RE_MATCH = r"(?P<name>[\w_-]+)\s+(?P<proto>\w+)\s+(?P<table>\w+)\s+(?P<state>\w+)\s+(?P<since>((|\d\d\d\d-\d\d-\d\d\s)(|\d\d:)\d\d:\d\d|\w\w\w\d\d))($|\s+(?P<info>.*))"
 
 
 @app.route("/summary/<hosts>")


### PR DESCRIPTION
Changed:
SUMMARY_RE_MATCH = r"(?P<name>[\w_]
to
SUMMARY_RE_MATCH = r"(?P<name>[\w_-]

to allow matching of names that contain a hyphen, "-". 

This will allow names with hypens to show up in the lg and avoid errors like
couldn't parse: ASxxx-1 BGP      master   up     23:20:46    Established