### PR TITLE
bind lgproxy.py optionally to an IP

### DIFF
--- a/lgproxy.cfg
+++ b/lgproxy.cfg
@@ -2,6 +2,8 @@
 DEBUG=False
 LOG_FILE="/var/log/lg-proxy/lg-proxy.log"
 LOG_LEVEL="WARNING"
+BIND_IP = "0.0.0.0"
+BIND_PORT = 5000
 ACCESS_LIST = ["91.224.149.206", "178.33.111.110", "2a01:6600:8081:ce00::1"]
 IPV4_SOURCE=""
 IPV6_SOURCE=""

--- a/lgproxy.py
+++ b/lgproxy.py
@@ -111,5 +111,4 @@ def bird():
 
 if __name__ == "__main__":
     app.logger.info("lgproxy start")
-    app.run("0.0.0.0")
-
+    app.run(app.config.get("BIND_IP", "0.0.0.0"), app.config.get("BIND_PORT", 5000))


### PR DESCRIPTION
Add the options
  BIND_IP = "0.0.0.0"
  BIND_PORT = 5000
which allows to bind lgproxy.py to an IP/interface.

As ports on routers shouldn't be exposed too much, it probably also makes sense to others to have this function.