### PR TITLE
Simplify parsing of 'show protocols' to avoid future breakages

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -223,8 +223,6 @@ def whois():
 
 
 SUMMARY_UNWANTED_PROTOS = ["Kernel", "Static", "Device"]
-SUMMARY_RE_MATCH = r"(?P<name>[\w_]+)\s+(?P<proto>\w+)\s+(?P<table>\w+)\s+(?P<state>\w+)\s+(?P<since>((|\d\d\d\d-\d\d-\d\d\s)|(\d\d:)\d\d:\d\d|\w\w\w\d\d))($|\s+(?P<info>.*))"
-
 
 @app.route("/summary/<hosts>")
 @app.route("/summary/<hosts>/<proto>")
@@ -251,9 +249,16 @@ def summary(hosts, proto="ipv4"):
         for line in res[1:]:
             line = line.strip()
             if line and (line.split() + [""])[1] not in SUMMARY_UNWANTED_PROTOS:
-                m = re.match(SUMMARY_RE_MATCH, line)
-                if m:
-                    data.append(m.groupdict())
+                split = line.split()
+                if len(split) >= 5:
+                    props = dict()
+                    props["name"] = split[0]
+                    props["proto"] = split[1]
+                    props["table"] = split[2]
+                    props["state"] = split[3]
+                    props["since"] = split[4]
+                    props["info"] = ' '.join(split[5:]) if len(split) > 5 else ""
+                    data.append(props)
                 else:
                     app.logger.warning("couldn't parse: %s", line)
 


### PR DESCRIPTION
The current parsing method (ugly regexp) is hard to understand and prone
to breakage:

- Bird 1.4 changed the date format, which broke the parser ()
- Bird 2.0 changed the format of the "Table" field, which again broke the parser (#36)

The new method is much simpler, does not involve any regexp, and should
thus resist small syntax changes in Bird's output.

Important limitation: parsing will be messed up if the date contains a
space character.  There is no space in the default date format of Bird
(checked with Bird 1.3 to Bird 2.0), but since the date format is
configurable in Bird, it may happen anyway.  In particular, setting
"timeformat protocol iso long" in Bird will break bird-lg's parser.

Fixes #36