### PR TITLE
Allow dash (-) in protocol names

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -223,7 +223,7 @@ def whois():
 
 
 SUMMARY_UNWANTED_PROTOS = ["Kernel", "Static", "Device"]
-SUMMARY_RE_MATCH = r"(?P<name>[\w_]+)\s+(?P<proto>\w+)\s+(?P<table>\w+)\s+(?P<state>\w+)\s+(?P<since>((|\d\d\d\d-\d\d-\d\d\s)|(\d\d:)\d\d:\d\d|\w\w\w\d\d))($|\s+(?P<info>.*))"
+SUMMARY_RE_MATCH = r"(?P<name>[\w_-]+)\s+(?P<proto>\w+)\s+(?P<table>\w+)\s+(?P<state>\w+)\s+(?P<since>((|\d\d\d\d-\d\d-\d\d\s)|(\d\d:)\d\d:\d\d|\w\w\w\d\d))($|\s+(?P<info>.*))"
 
 
 @app.route("/summary/<hosts>")


### PR DESCRIPTION
Parsing protocol names fails when they include a dash (`-`).

```
couldn't parse: ffrl-a-ak-ber BGP      ffrl     up     2018-09-17 08:51:01  Established
couldn't parse: ffrl-b-ak-ber BGP      ffrl     up     2018-09-17 08:51:04  Established
couldn't parse: ffrl-a-ix-dus BGP      ffrl     up     2018-09-17 08:50:59  Established
couldn't parse: ffrl-b-ix-dus BGP      ffrl     up     2018-09-17 08:51:01  Established
couldn't parse: ffrl-a-fra2-fra BGP      ffrl     up     2018-09-17 08:51:02  Established
couldn't parse: ffrl-b-fra2-fra BGP      ffrl     up     2018-09-17 08:51:01  Established

```