### PR TITLE
Correctly parse aspath for both bird 1.x and 2.0

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -491,7 +491,10 @@ def show_bgpmap():
                         hop_label = ""
 
                 
-                add_node(_as, fillcolor=(first and "#F5A9A9" or "white"))
+                if _as == asmap[-1]:
+                    add_node(_as, fillcolor="#F5A9A9", shape="box", )
+                else:
+                    add_node(_as, fillcolor=(first and "#F5A9A9" or "white"), )
                 if hop_label:
                     edge = add_edge(nodes[previous_as], nodes[_as], label=hop_label, fontsize="7")
                 else:
@@ -499,19 +502,15 @@ def show_bgpmap():
 
                 hop_label = ""
 
-                if first:
+                if first or _as == asmap[-1]:
                     edge.set_style("bold")
                     edge.set_color("red")
-                elif edge.get_color() != "red":
+                elif edge.get_style() != "bold":
                     edge.set_style("dashed")
                     edge.set_color(color)
 
                 previous_as = _as
             first = False
-
-    if previous_as:
-        node = add_node(previous_as)
-        node.set_shape("box")
 
     for _as in prepend_as:
         graph.add_edge(pydot.Edge(*(_as, _as), label=" %dx" % prepend_as[_as], color="grey", fontcolor="grey"))

--- a/static/js/lg.js
+++ b/static/js/lg.js
@@ -14,7 +14,7 @@ function reload(){
 	loc = "/" + request_type + "/" + hosts + "/" + proto;
 	if (request_type != "summary" ){
 		if( request_args != undefined && request_args != ""){
-			loc = loc + "?q=" + escape(request_args);
+			loc = loc + "?q=" + encodeURIComponent(request_args);
 			change_url(loc)
 		} 
 	} else {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,7 +84,7 @@
 							<li class="nav-header">Request history</li>
 							{% for hosts, proto, request_type, request_args in session.history %}
 							<li{% if loop.first %} class="active"{% endif %}>
-							<a href="/{{ [request_type, hosts, proto]|join("/") }}{% if request_args %}?q={{request_args}}{% endif %}">
+							<a href="/{{ [request_type, hosts, proto]|join("/") }}{% if request_args %}?q={{request_args|urlencode}}{% endif %}">
 								{{hosts}}/{{proto}}: {{ commands_dict[request_type]|replace("...", request_args) }}
 							</a>
 							</li>

--- a/templates/route.html
+++ b/templates/route.html
@@ -3,7 +3,7 @@
 {% for host in detail %}
 <h3>
     {{host}}: {{command}}
-    <small><a class="pull-right" href="/{{session.request_type|replace("_detail","")}}_bgpmap/{{session.hosts}}/{{session.proto}}?q={{session.request_args}}">View the BGP map</a></small>
+    <small><a class="pull-right" href="/{{session.request_type|replace("_detail","")}}_bgpmap/{{session.hosts}}/{{session.proto}}?q={{session.request_args|urlencode}}">View the BGP map</a></small>
 </h3>
 {% if session.request_args != expression|replace("/32","")|replace("/128","") %}
 <i>DNS: <a href="/whois/{{session.request_args}}" class="whois">{{session.request_args}}</a> => <a href="/whois/{{ expression|replace("/32","")|replace("/128","") }}" class="whois">{{expression|replace("/32","")|replace("/128","")}}</a></i><br />


### PR DESCRIPTION
Without this patch `build_as_tree_from_raw_bird_ouput()` fails on bird-2.0.