### PR TITLE
Hyperlink ASN only when square-bracketed

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -76,7 +76,7 @@ def add_links(text):
             ret_text.append(re.sub(r'(\d+)', r'<a href="/whois?q=\1" class="whois">\1</a>', line))
         else:
             line = re.sub(r'([a-zA-Z0-9\-]*\.([a-zA-Z]{2,3}){1,2})(\s|$)', r'<a href="/whois?q=\1" class="whois">\1</a>\3', line)
-            line = re.sub(r'AS(\d+)', r'<a href="/whois?q=\1" class="whois">AS\1</a>', line)
+            line = re.sub(r'(?<=\[)AS(\d+)', r'<a href="/whois?q=\1" class="whois">AS\1</a>', line)
             line = re.sub(r'(\d+\.\d+\.\d+\.\d+)', r'<a href="/whois?q=\1" class="whois">\1</a>', line)
             if len(request.path) >= 2:
                 hosts = "/".join(request.path.split("/")[2:])


### PR DESCRIPTION
When `show protocols all ...` is selected, bird's output includes `AS4` to suggest 4-byte ASN capability, which bird-lg in turn treats like an ASN and creates a whois hyperlink. 

![image](https://user-images.githubusercontent.com/5856531/55528273-35147000-56d7-11e9-9d61-4fa2e491c677.png)

The patch I'm submitting tweaks regex with positive lookbehind assertion so it matches only when preceded by `[` which is kind of a dirty hack but I believe is less confusing for users. 