### PR TITLE
Prevent 4-byte AS capability from being treated like it is ASN

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -76,7 +76,7 @@ def add_links(text):
             ret_text.append(re.sub(r'(\d+)', r'<a href="/whois?q=\1" class="whois">\1</a>', line))
         else:
             line = re.sub(r'([a-zA-Z0-9\-]*\.([a-zA-Z]{2,3}){1,2})(\s|$)', r'<a href="/whois?q=\1" class="whois">\1</a>\3', line)
-            line = re.sub(r'AS(\d+)', r'<a href="/whois?q=\1" class="whois">AS\1</a>', line)
+            line = re.sub(r'(?<=\[)AS(\d+)', r'<a href="/whois?q=\1" class="whois">AS\1</a>', line)
             line = re.sub(r'(\d+\.\d+\.\d+\.\d+)', r'<a href="/whois?q=\1" class="whois">\1</a>', line)
             if len(request.path) >= 2:
                 hosts = "/".join(request.path.split("/")[2:])


### PR DESCRIPTION
Bird displays neighbor's 4-byte AS capability as `AS4`.
This patch prevents it from being treated as an clickable ASN in the output of `show protocols <protocol_name> all` response.