### PR TITLE
Encode `+` when it appears in URL.

### DIFF
--- a/static/js/lg.js
+++ b/static/js/lg.js
@@ -14,7 +14,7 @@ function reload(){
 	loc = "/" + request_type + "/" + hosts + "/" + proto;
 	if (request_type != "summary" ){
 		if( request_args != undefined && request_args != ""){
-			loc = loc + "?q=" + escape(request_args);
+			loc = loc + "?q=" + encodeURIComponent(request_args);
 			change_url(loc)
 		} 
 	} else {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -84,7 +84,7 @@
 							<li class="nav-header">Request history</li>
 							{% for hosts, proto, request_type, request_args in session.history %}
 							<li{% if loop.first %} class="active"{% endif %}>
-							<a href="/{{ [request_type, hosts, proto]|join("/") }}{% if request_args %}?q={{request_args}}{% endif %}">
+							<a href="/{{ [request_type, hosts, proto]|join("/") }}{% if request_args %}?q={{request_args|urlencode}}{% endif %}">
 								{{hosts}}/{{proto}}: {{ commands_dict[request_type]|replace("...", request_args) }}
 							</a>
 							</li>

--- a/templates/route.html
+++ b/templates/route.html
@@ -3,7 +3,7 @@
 {% for host in detail %}
 <h3>
     {{host}}: {{command}}
-    <small><a class="pull-right" href="/{{session.request_type|replace("_detail","")}}_bgpmap/{{session.hosts}}/{{session.proto}}?q={{session.request_args}}">View the BGP map</a></small>
+    <small><a class="pull-right" href="/{{session.request_type|replace("_detail","")}}_bgpmap/{{session.hosts}}/{{session.proto}}?q={{session.request_args|urlencode}}">View the BGP map</a></small>
 </h3>
 {% if session.request_args != expression|replace("/32","")|replace("/128","") %}
 <i>DNS: <a href="/whois/{{session.request_args}}" class="whois">{{session.request_args}}</a> => <a href="/whois/{{ expression|replace("/32","")|replace("/128","") }}" class="whois">{{expression|replace("/32","")|replace("/128","")}}</a></i><br />


### PR DESCRIPTION
This patch takes care of encoding `+` within URL, such as `View the BGP map` link on the output of `show route where net ~ [ <prefix> + ]` response.