### PR TITLE
DEBUG should be disabled as default

### DIFF
--- a/lg.cfg
+++ b/lg.cfg
@@ -1,5 +1,5 @@
 
-DEBUG = True
+DEBUG = False
 LOG_FILE="/var/log/lg.log"
 LOG_LEVEL="WARNING"
 


### PR DESCRIPTION
DEBUG = True is an insecure default. It should be disabled by default.