### PR TITLE
Fix XSS on whois modal

### DIFF
--- a/lg.py
+++ b/lg.py
@@ -218,7 +218,7 @@ def whois():
         if m:
             query = query.groupdict()["domain"]
 
-    output = whois_command(query).replace("\n", "<br>")
+    output = whois_command(query)
     return jsonify(output=output, title=query)
 
 

--- a/static/js/lg.js
+++ b/static/js/lg.js
@@ -58,7 +58,7 @@ $(function(){
 			link = $(this).attr('href');
 			$.getJSON(link, function(data) {
 				$(".modal h3").html(data.title);
-			        $(".modal .modal-body > p").html(data.output);
+			        $(".modal .modal-body > p").css("white-space", "pre-line").text(data.output);
 				$(".modal").modal('show');
 			});
 		});


### PR DESCRIPTION
While looking around in NLNOG RING LG, I saw that my small XSS script in my ASN WHOIS record triggered whenever I clicked on my ASN.

The proposed PR removes the modification of WHOIS data on the endpoint and adds a small CSS to the WHOIS modal to handle raw newlines.

This can also be fixed by reusing the `escape` function used in `lg.py`.