### PR TITLE
Add SHARED_SECRET

### DIFF
--- a/lg.cfg
+++ b/lg.cfg
@@ -5,6 +5,9 @@ LOG_LEVEL="WARNING"
 
 DOMAIN = "tetaneutral.net"
 
+# Used for restrict access on lgproxy - must be same in lgproxy.cfg
+SHARED_SECRET="ThisTokenIsNotSecret"
+
 BIND_IP = "0.0.0.0"
 BIND_PORT = 5000
 

--- a/lg.py
+++ b/lg.py
@@ -153,7 +153,8 @@ def bird_proxy(host, proto, service, query):
     if "DOMAIN" in app.config:
         url = "%s.%s" % (url, app.config["DOMAIN"])
     url = "%s:%d/%s?" % (url, port, path)
-
+    if "SHARED_SECRET" in app.config:
+        url = "%ssecret=%s&" % (url, app.config["SHARED_SECRET"])
     url = "%sq=%s" % (url, quote(query))
 
     try:

--- a/lgproxy.cfg
+++ b/lgproxy.cfg
@@ -1,12 +1,21 @@
 
 DEBUG=False
+
 LOG_FILE="/var/log/lg-proxy/lg-proxy.log"
 LOG_LEVEL="WARNING"
+
 BIND_IP = "0.0.0.0"
 BIND_PORT = 5000
+
+# Used for restrict access on lgproxy - Empty list = all allowed
 ACCESS_LIST = ["91.224.149.206", "178.33.111.110", "2a01:6600:8081:ce00::1"]
+
+# Used for restrict access on lgproxy - Must be same in lg.cfg
+SHARED_SECRET="ThisTokenIsNotSecret"
+
 IPV4_SOURCE=""
 IPV6_SOURCE=""
+
 BIRD_SOCKET="/var/run/bird/bird.ctl"
 BIRD6_SOCKET="/var/run/bird/bird6.ctl"
 


### PR DESCRIPTION
Add new parameter "SHARED_SECRET" in lg.cfg and lgproxy.cfg to secure connection between lg and lgproxy.

The parameter must be secret and can be cumulated with "ACCESS_LIST".