### PR TITLE
Make Docker images for lg / lgproxy

### DIFF
--- a/Dockerfile.lg
+++ b/Dockerfile.lg
@@ -1,0 +1,31 @@
+FROM debian:buster-slim
+
+ENV LGUID 65534
+ENV LGGID 65534
+
+EXPOSE 8000
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    python-flask \
+    traceroute \
+    netbase \
+    gunicorn \
+    python-dnspython \
+    graphviz \
+    python-pydot \
+    python-memcache \
+    whois
+
+WORKDIR /bird-lg
+
+ADD lg.* /bird-lg/
+ADD templates/ /bird-lg/templates/
+ADD static/ /bird-lg/static/
+ADD toolbox.py /bird-lg/
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["lg:app"]

--- a/Dockerfile.lgproxy
+++ b/Dockerfile.lgproxy
@@ -1,0 +1,24 @@
+FROM debian:buster-slim
+
+ENV LGUID 65534
+ENV LGGID 65534
+
+EXPOSE 8000
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    python-flask \
+    traceroute \
+    netbase \
+    gunicorn
+
+WORKDIR /bird-lg
+
+ADD lgproxy.* /bird-lg/
+ADD bird.py /bird-lg/
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["lgproxy:app"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+chown "${LGUID}:${LGGID}" /dev/stdout
+
+exec gunicorn -u "${LGUID}" -g "${LGGID}" -b 0.0.0.0:8000 $@


### PR DESCRIPTION
We are currently using lg and lgproxy in Docker containers. Would you like to include this branch in the repositories?

The installation of a construction chain is described here: https://medium.com/better-programming/build-your-docker-images-automatically-when-you-push-on-github-18e80ece76af