### PR TITLE
Allow setting log history size

### DIFF
--- a/lg.cfg
+++ b/lg.cfg
@@ -2,6 +2,8 @@ WEBSITE_TITLE="Bird-LG / Looking Glass"
 DEBUG = False
 LOG_FILE="/var/log/lg.log"
 LOG_LEVEL="WARNING"
+# Keep log history indefinitely by default.
+LOG_NUM_DAYS=0
 
 DOMAIN = "tetaneutral.net"
 

--- a/lg.py
+++ b/lg.py
@@ -48,7 +48,7 @@ app.config.from_pyfile(args.config_file)
 app.secret_key = app.config["SESSION_KEY"]
 app.debug = app.config["DEBUG"]
 
-file_handler = TimedRotatingFileHandler(filename=app.config["LOG_FILE"], when="midnight")
+file_handler = TimedRotatingFileHandler(filename=app.config["LOG_FILE"], when="midnight", backupCount=app.config.get("LOG_NUM_DAYS", 0))
 file_handler.setLevel(getattr(logging, app.config["LOG_LEVEL"].upper()))
 app.logger.addHandler(file_handler)
 

--- a/lgproxy.cfg
+++ b/lgproxy.cfg
@@ -3,6 +3,8 @@ DEBUG=False
 
 LOG_FILE="/var/log/lg-proxy/lg-proxy.log"
 LOG_LEVEL="WARNING"
+# Keep log history indefinitely by default.
+LOG_NUM_DAYS=0
 
 BIND_IP = "0.0.0.0"
 BIND_PORT = 5000

--- a/lgproxy.py
+++ b/lgproxy.py
@@ -41,7 +41,7 @@ app = Flask(__name__)
 app.debug = app.config["DEBUG"]
 app.config.from_pyfile(args.config_file)
 
-file_handler = TimedRotatingFileHandler(filename=app.config["LOG_FILE"], when="midnight")
+file_handler = TimedRotatingFileHandler(filename=app.config["LOG_FILE"], when="midnight", backupCount=app.config.get("LOG_NUM_DAYS", 0))
 app.logger.setLevel(getattr(logging, app.config["LOG_LEVEL"].upper()))
 app.logger.addHandler(file_handler)
 


### PR DESCRIPTION
BIRD-LG currently keeps log files indefinitely. This patch allows setting the number of days logs should be kept for by adding
a `LOG_NUM_DAYS` parameter in the configuration files.

This change is backwards compatible: Running the updated code with old configuration files will keep logs indefinitely as before; new deployments based on the example configuration will keep logs indefinitely.