### PR TITLE
Generalize requests without arguments in JS

### DIFF
--- a/static/js/lg.js
+++ b/static/js/lg.js
@@ -1,4 +1,4 @@
-
+const noArgReqs = ["summary"];
 
 $(window).unload(function(){
 		$(".progress").show()
@@ -12,7 +12,7 @@ function change_url(loc){
 
 function reload(){
 	loc = "/" + request_type + "/" + hosts + "/" + proto;
-	if (request_type != "summary" ){
+	if (!noArgReqs.includes(request_type)){
 		if( request_args != undefined && request_args != ""){
 			loc = loc + "?q=" + encodeURIComponent(request_args);
 			change_url(loc)
@@ -22,7 +22,7 @@ function reload(){
 	}
 }
 function update_view(){
-	if (request_type == "summary")
+	if (noArgReqs.includes(request_type))
 		$(".navbar-search").hide();
 	else
 		$(".navbar-search").show();


### PR DESCRIPTION
This commit adds a list of request types that do not have parameters. These requests are handled different by the JS code, and
the list makes it easier to add new custom commands that do not have arguments.